### PR TITLE
0001 standardize naming of env vars

### DIFF
--- a/.github/workflows/updateMembers.yml
+++ b/.github/workflows/updateMembers.yml
@@ -9,8 +9,8 @@ jobs:
     steps:
       - name: Call Supabase Edge Function
         env:
-          SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           curl -X POST "$SUPABASE_URL/functions/v1/updateMembers" \
-               -H "Authorization: Bearer $VITE_SUPABASE_SERVICE_ROLE_KEY"
+               -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY"

--- a/run_supabase_function.sh
+++ b/run_supabase_function.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 source .env
-curl -X POST "$VITE_SUPABASE_URL/functions/v1/updateMembers" -H "Authorization: Bearer $VITE_SUPABASE_SERVICE_ROLE_KEY"
+curl -X POST "$SUPABASE_URL/functions/v1/updateMembers" -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY"
 chmod +x run_supabase_function.sh

--- a/src/pages/Swipe.tsx
+++ b/src/pages/Swipe.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { fetchData, addMembers, getMemberSponsoredLegislation } from "../api/apiHelper";
+import { fetchData, addMembers, getMemberSponsoredLegislation } from "../utils/apiHelper";
 
 const Swipe = () => {
   const [data, setData] = useState<any[]>([]);

--- a/src/utils/apiHelper.tsx
+++ b/src/utils/apiHelper.tsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const API_KEY = import.meta.env.VITE_CONGRESS_API_KEY;
+const API_KEY = process.env.CONGRESS_API_KEY;
 const BASE_URL = "https://api.congress.gov/v3";
 
 /**
@@ -64,7 +64,6 @@ const getLegislationInfo = async (url: string) => {
   export const getMemberSponsoredLegislation = async (bioguideId: string) => {
     try {
       const response = await axios.get(`${BASE_URL}/member/${bioguideId}/sponsored-legislation?api_key=${API_KEY}`);
-      console.log(response.data);
       const legislationList = response.data?.sponsoredLegislation || []; // Handle cases where legislation is missing
   
       // Fetch additional info for each piece of legislation in parallel

--- a/src/utils/loadEnv.ts
+++ b/src/utils/loadEnv.ts
@@ -1,0 +1,12 @@
+import dotenv from "dotenv";
+
+dotenv.config();
+
+export default {
+  CONGRESS_API_KEY: process.env.CONGRESS_API_KEY,
+  SUPABASE_URL: process.env.SUPABASE_URL,
+  SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY,
+  SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
+  DB_UPDATE_TOKEN: process.env.DB_UPDATE_TOKEN,
+  STEVE_TEST: process.env.STEVE_TEST,
+};

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,8 +1,8 @@
 
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl = import.meta.env.SUPABASE_URL;
+const supabaseKey = import.meta.env.SUPABASE_ANON_KEY;
 const supabase = createClient(supabaseUrl, supabaseKey);
 
 export default supabase;

--- a/supabase/functions/updateMembers/index.ts
+++ b/supabase/functions/updateMembers/index.ts
@@ -5,12 +5,12 @@ import { config } from "https://deno.land/x/dotenv/mod.ts";
 console.log("Current working directory:", Deno.cwd());
 
 const env = config();
-const SUPABASE_URL = env.VITE_SUPABASE_URL;
-const SUPABASE_SERVICE_ROLE_KEY = env.VITE_SUPABASE_SERVICE_ROLE_KEY;
-const CONGRESS_API_KEY = env.VITE_CONGRESS_API_KEY;
+const SUPABASE_URL = env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = env.SUPABASE_SERVICE_ROLE_KEY;
+const CONGRESS_API_KEY = env.CONGRESS_API_KEY;
 
 if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY || !CONGRESS_API_KEY) {
-  throw new Error("Missing required environment variables: VITE_SUPABASE_URL, VITE_SUPABASE_SERVICE_ROLE_KEY, or VITE_CONGRESS_API_KEY");
+  throw new Error("Missing required environment variables: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, or CONGRESS_API_KEY");
 }
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import envVars from "../LearnCongress/src/utils/loadEnv"
 
 
 // https://vite.dev/config/
@@ -10,6 +11,9 @@ export default defineConfig({
     tailwindcss(),
     
   ],
+  define: {
+    "process.env": envVars,
+  },
   server: {
     watch: {
       usePolling: true


### PR DESCRIPTION
### SUMMARY
renamed all references to env vars to remove the `VITE_` prefix.

with this, i also improved the way I read in env vars from the .env file. now it uses loadEnv, which registers and exports the vars using the dotenv lib. this should standardize the way I refer to them going forward. 

### TESTING
post-merge testing includes running the github action and corresponding supabase edge function and seeing that they both pass with expected results. i am hoping to see the members table in our DB be filled in with values of the expected types, and minimal nulls.

first ticket!